### PR TITLE
chore: bring back base.archivesName to old format

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,7 @@ android {
         versionName = "v4.1.1"
 
         multiDexEnabled = true
+        base.archivesName.set("${defaultConfig.versionName}(${defaultConfig.versionCode})")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -123,10 +124,13 @@ android {
             applicationId = "ltd.grunt.brainwallet.screengrab"
             versionNameSuffix = "-screengrab"
             resValue("string", "app_name", "Brainwallet (screengrab)")
-            buildConfigField("String[]", "SCREENGRAB_PAPERKEY", 
-                "new String[] {${localProperties.getProperty("SCREENGRAB_PAPERKEY", "")
-                    .split(" ")
-                    .joinToString { "\"$it\"" }}}")
+            buildConfigField("String[]", "SCREENGRAB_PAPERKEY",
+                "new String[] {${
+                    localProperties.getProperty("SCREENGRAB_PAPERKEY", "")
+                        .split(" ")
+                        .joinToString { "\"$it\"" }
+                }}"
+            )
 
             externalNativeBuild {
                 cmake {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,11 +27,30 @@ platform :android do
     gradle(
         tasks: ['clean', 'assembleScreengrabDebug', 'assembleScreengrabAndroidTest']
     )
+    build_dir = "#{ENV['PWD']}/app/build/"
+    UI.message "Build directory: #{build_dir}"
+    
+    # Check if APK files exist
+    app_apk = "#{build_dir}/outputs/apk/screengrab/debug/*screengrab-debug.apk"
+    test_apk = "#{build_dir}/outputs/apk/androidTest/screengrab/debug/*screengrab-debug-androidTest.apk"
+
+    app_apks = Dir.glob(app_apk)
+    test_apks = Dir.glob(test_apk)
+    if app_apks.empty?
+      UI.user_error!("App APK file not found. Please check the build output directory.")
+    end
+
+    if test_apks.empty?
+      UI.user_error!("Test APK file not found. Please check the build output directory.")
+    end
+    app_apk = app_apks.first
+    test_apk = test_apks.first
+
     screengrab(
-        clear_previous_screenshots: true,
-        app_package_name: 'ltd.grunt.brainwallet.screengrab',
-        app_apk_path: "app/build/outputs/apk/screengrab/debug/app-screengrab-debug.apk",
-        tests_apk_path: "app/build/outputs/apk/androidTest/screengrab/debug/app-screengrab-debug-androidTest.apk"
+      clear_previous_screenshots: true,
+      app_package_name: 'ltd.grunt.brainwallet.screengrab',
+      app_apk_path: app_apk,
+      tests_apk_path: test_apk
     )
   end
 


### PR DESCRIPTION
## Overview
* Bring back artifact file e.g. `.apk` with `base.archivesName` from old format `versionName(versionCode)`
* Also adjustment for Fastfile regarding screengrab implementation

## Example Output

| Before | After |
|-------|-------|
| `app-screengrab-debug.apk` | `v4.1.1(202501262)-screengrab-debug.apk` |