### PR TITLE
Bug: Restore screen shows duplicate suggestion lists

### DIFF
--- a/app/src/main/java/com/brainwallet/ui/composable/SeedWordItem.kt
+++ b/app/src/main/java/com/brainwallet/ui/composable/SeedWordItem.kt
@@ -3,6 +3,7 @@ package com.brainwallet.ui.composable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -19,6 +20,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,7 +28,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.DpOffset
@@ -34,7 +35,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.brainwallet.ui.theme.BrainwalletTheme
 import com.brainwallet.ui.theme.chilli
-import com.brainwallet.ui.theme.darken
 
 @Composable
 fun SeedWordItem(
@@ -91,6 +91,13 @@ fun SeedWordItemTextField(
 ) {
     var suggestionsExpanded by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    LaunchedEffect(isFocused) {
+        if (!isFocused) {
+            suggestionsExpanded = false // Dismiss dropdown when focus is lost
+        }
+    }
 
     Box(modifier = modifier) {
         BasicTextField(
@@ -127,7 +134,8 @@ fun SeedWordItemTextField(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .background(
-                    color = BrainwalletTheme.colors.background.copy(alpha = 0.3f), shape = MaterialTheme.shapes.medium
+                    color = BrainwalletTheme.colors.background.copy(alpha = 0.3f),
+                    shape = MaterialTheme.shapes.medium
                 )
                 .heightIn(max = 250.dp),
             properties = PopupProperties(focusable = false),

--- a/app/src/main/java/com/brainwallet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/brainwallet/ui/theme/Theme.kt
@@ -70,6 +70,8 @@ object BrainwalletTheme {
     val colors: BrainwalletColors
         @Composable
         get() = LocalBrainwalletColors.current
+
+    //todo: add typography, shape? for the design system
 }
 
 //provide compose theme wrapper for transition


### PR DESCRIPTION
## Overview
fix issue when entering the seed phrase, the other fields are still in focus

## Internal Issue
* https://github.com/gruntsoftware/internal/issues/72

## Self Test
| Before | After |
|--------|------|
|  ![before1](https://github.com/user-attachments/assets/dfd68a30-6f3f-4ca7-bb41-bb07179797f5) | ![after1](https://github.com/user-attachments/assets/623317d3-491c-4ffc-bb01-b1b4385c964a) |
