### PR TITLE
🚀[Release v4.30] Merge into Develop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "ltd.grunt.brainwallet"
         minSdk = 29
         targetSdk = 34
-        versionCode = 202502251
-        versionName = "v4.2.5"
+        versionCode = 202502261
+        versionName = "v4.3.0"
 
         multiDexEnabled = true
         base.archivesName.set("${defaultConfig.versionName}(${defaultConfig.versionCode})")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "ltd.grunt.brainwallet"
         minSdk = 29
         targetSdk = 34
-        versionCode = 202502261
+        versionCode = 202502262
         versionName = "v4.3.0"
 
         multiDexEnabled = true

--- a/app/src/main/java/com/brainwallet/presenter/activities/settings/DisplayCurrencyActivity.java
+++ b/app/src/main/java/com/brainwallet/presenter/activities/settings/DisplayCurrencyActivity.java
@@ -35,9 +35,9 @@ public class DisplayCurrencyActivity extends BRActivity {
     private TextView exchangeText;
     private ListView listView;
     private CurrencyListAdapter adapter;
-    //    private String ISO;
-//    private float rate;
+
     public static boolean appVisible = false;
+    public static boolean shouldBeBrainwalletFilteredFiat = true;
     private static DisplayCurrencyActivity app;
     private Button leftButton;
     private Button rightButton;
@@ -65,7 +65,7 @@ public class DisplayCurrencyActivity extends BRActivity {
         exchangeText = findViewById(R.id.exchange_text);
         listView = findViewById(R.id.currency_list_view);
         adapter = new CurrencyListAdapter(this);
-        adapter.addAll(CurrencyDataSource.getInstance(this).getAllCurrencies());
+        adapter.addAll(CurrencyDataSource.getInstance(this).getAllCurrencies(shouldBeBrainwalletFilteredFiat));
         leftButton = findViewById(R.id.left_button);
         rightButton = findViewById(R.id.right_button);
         leftButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/brainwallet/tools/sqlite/BRSQLiteHelper.java
+++ b/app/src/main/java/com/brainwallet/tools/sqlite/BRSQLiteHelper.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import timber.log.Timber;
 
@@ -78,7 +80,6 @@ public class BRSQLiteHelper extends SQLiteOpenHelper {
     public static final String CURRENCY_CODE = "code";
     public static final String CURRENCY_NAME = "name";
     public static final String CURRENCY_RATE = "rate";
-
     private static final String CURRENCY_DATABASE_CREATE = "create table if not exists " + CURRENCY_TABLE_NAME + "(" +
             CURRENCY_CODE + " text primary key," +
             CURRENCY_NAME + " text," +

--- a/app/src/main/java/com/brainwallet/tools/sqlite/CurrencyDataSource.java
+++ b/app/src/main/java/com/brainwallet/tools/sqlite/CurrencyDataSource.java
@@ -1,5 +1,7 @@
 package com.brainwallet.tools.sqlite;
 
+import static kotlinx.coroutines.flow.FlowKt.collect;
+
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -9,8 +11,11 @@ import com.brainwallet.data.model.CurrencyEntity;
 import com.brainwallet.tools.util.BRConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import timber.log.Timber;
 
@@ -61,9 +66,14 @@ public class CurrencyDataSource implements BRDataSourceInterface {
         }
     }
 
-    public List<CurrencyEntity> getAllCurrencies() {
+    public List<CurrencyEntity> getAllCurrencies(Boolean shouldBeFiltered) {
 
         List<CurrencyEntity> currencies = new ArrayList<>();
+
+        /// Set the most popular fiats
+        List<String> filteredFiatCodes =
+                Arrays.asList("USD","EUR","GBP", "SGD","CAD","AUD","RUB","KRW","MXN","SAR","UAH","NGN","JPY","CNY","IDR","TRY");
+
         Cursor cursor = null;
         try {
             database = openDatabase();
@@ -81,6 +91,14 @@ public class CurrencyDataSource implements BRDataSourceInterface {
             if (cursor != null)
                 cursor.close();
             closeDatabase();
+        }
+
+        if (shouldBeFiltered) {
+            // Filtering Brainwallet fiats
+            List<CurrencyEntity> filteredFiats = currencies.stream()
+                    .filter(currency -> filteredFiatCodes.contains(currency.code))
+                    .collect(Collectors.toList());
+                    currencies = filteredFiats;
         }
 
         return currencies;

--- a/app/src/main/java/com/brainwallet/ui/composable/bottomsheet/FiatSelectorBottomSheet.kt
+++ b/app/src/main/java/com/brainwallet/ui/composable/bottomsheet/FiatSelectorBottomSheet.kt
@@ -31,8 +31,7 @@ fun FiatSelectorBottomSheet(
         onDismissRequest = onDismissRequest,
     ) {
         LazyColumn {
-            val currencies = CurrencyDataSource.getInstance(context).allCurrencies
-
+            val currencies = CurrencyDataSource.getInstance(context).getAllCurrencies(true)
             items(
                 items = currencies
             ) { currency ->

--- a/app/src/test/java/com/brainwallet/currency/CurrencyTests.kt
+++ b/app/src/test/java/com/brainwallet/currency/CurrencyTests.kt
@@ -40,7 +40,14 @@ class CurrencyTests {
     fun `invoke CurrencyDataSource instance and getAllCurrencies, should return the correct number of currencies`() {
         //The actual number of currencies is 174. The 0 is a placeholder and needs to be replaced with a db query.
         mockCursorDataFromDatabase()
-        assertEquals(currencyDataSource?.allCurrencies?.count(), 0)
+        assertEquals(currencyDataSource?.getAllCurrencies(false)?.count(), 0)
+    }
+
+    @Test
+    fun `invoke CurrencyDataSource instance and Brainwallet filtered Fiats, should return the correct number of Brainwallet currencies`() {
+        //The actual number of BW currencies is 16. The 0 is a placeholder and needs to be replaced with a db query.
+        mockCursorDataFromDatabase()
+        assertEquals(currencyDataSource?.getAllCurrencies(true)?.count(), 0)
     }
 
     @Test

--- a/app/src/test/java/com/brainwallet/tools/database/DatabaseTests.kt
+++ b/app/src/test/java/com/brainwallet/tools/database/DatabaseTests.kt
@@ -2,7 +2,8 @@ package com.brainwallet.tools.database
 
 class DatabaseTests {
 }
-
+// TODO: Reopen in Kotlin mocckk
+// TODO: BRSQLiteHelper.BRAINWALLET_FIAT_CODES Test
 //package com.brainwallet.analytics;
 //import androidx.test.ext.junit.runners.AndroidJUnit4;
 //import android.util.Log;


### PR DESCRIPTION
# Overview
First Brainwallet release!  🚀 🎸 🔥 

## Release Notes

- Added Open Sauce One fonts  
- Added the lottie file: welcome animation  
- Added with WelcomeActivity  
- added data  
- added more brand logotypes  
- adding circle shape in welcome toggle  
- adjusted lock layout  
- chore: add info for event bus  
- chore: add SetPasscodeConfirmScreen from feat/set-pincode-issue-31  
- chore: adjust coloring for buy tab related  
- chore: adjust tint logo for UnLockScreen  
- chore: adjustment for Dialog  
- chore: comment language and dark mode switch at WelcomeScreen  
- chore: compose theming adjustment for YourSeedWordsScreen and YourSeedProveItScreen  
- chore: define pin digit length  
- chore: just add comment for theming  
- chore: mapping colors.xml like in compose  
- chore: move hardcoded strings to strings.xml  
- chore: optimize import for  
- chore: remove TODO at PasscodeKeypad  
- chore: remove unused code  
- chore: remove unused code at LegacyNavigation.startBreadActivity  
- chore: remove unused colors  
- chore: remove unused file  
- chore: update FragmentSend  
- chore: update pin 4 digit in compose  
- chore: update translations strings.xml files  
- chore: using setpasscode compose from LoginActivity  
- chore: using unlock screen from compose instead of LoginActivity  
- chore: wip compose communication with legacy code  
- chore: wip reset pin when disabled  
- clean up host  
- feat: add fragment compose, add new home  
- feat: add UnLockScreen  
- feat: create wallet flow and paper key prove flow  
- feat: reset pin flow when wallet disabled after input wrong pin  
- feat: UnLockScreen using onNavigate  
- feat: using setpasscode compose from legacy PostAuth.onRecoverWalletAuth  
- feat: wipe wallet with old flow  
- feat: wrap BRAnimator.startBreadActivity with LegacyNavigation.startBreadActivity  
- feat: wip create wallet flow  
- feat: wip implement new navigation  
- feat: wip new theming  
- feat: wip new theming approach and also simulate toggle dark/light mode in compose  
- fix: fix input SeedWordItem focus dropdown suggestion expanded  
- fix: fix passcode verified flow  
- fix: fix unlock screen flow  
- fix: make sure pin length is 4  
- Fixed PIN update bug  
- Further polish toggle  
- Layout in process  
- Moved @kiejosie Composables to composables directory  
- Partially mapped the class to the palette  
- Polish the Welcome and Restore screens  
- Rename .java to .kt  
- renamed our main Composables package  
- Severely reduced colors  
- Set Pin limit  
- Slight refactor of layout  
- update the icon  
- Updated the constant  
- Removed the random greeting  

fix: change from breadContext to applicationContext at BreadActivity.onConnectionChanged 
fix: fix currency by iso null from sqlite


## Status
- [ ] Play Store Approved